### PR TITLE
Add Arrow/YAML/TOML crates, other small revisions

### DIFF
--- a/packages/panamax/.changeset/add-crates-misc-improvements.md
+++ b/packages/panamax/.changeset/add-crates-misc-improvements.md
@@ -1,0 +1,8 @@
+- Adds crates for Apache Arrow, YAML, and TOML
+- Add crates wincode and rkyv to replace bincode
+- Renamed mirror.toml.base to mirror.base.toml, to keep syntax highlighting in editors looking for the .toml extension
+- Added GNU and musl Rustup targets for both x86_64 and i686
+- I updated all crate versions
+- Rather than grouping by use, I organized alphabetically. That should help us avoid duplicates.
+- I had trouble getting Cargo.toml to resolve without a compile target, so I needed to create a trivial src/lib.rs.
+- Other small changes like specifying the container name in the docker-compose.yml

--- a/packages/panamax/.changeset/add-crates-misc-improvements.md
+++ b/packages/panamax/.changeset/add-crates-misc-improvements.md
@@ -1,3 +1,6 @@
++---
++panamax: minor
++---
 - Adds crates for Apache Arrow, YAML, and TOML
 - Add crates wincode and rkyv to replace bincode
 - Renamed mirror.toml.base to mirror.base.toml, to keep syntax highlighting in editors looking for the .toml extension

--- a/packages/panamax/Cargo.toml
+++ b/packages/panamax/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "panamax"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
-
-[lib]
-path = "src/lib.rs"
 
 [dependencies]
 arrow = { version = "58.0.0", features = [

--- a/packages/panamax/Cargo.toml
+++ b/packages/panamax/Cargo.toml
@@ -1,90 +1,90 @@
 [package]
 name = "panamax"
 version = "1.1.0"
-edition = "2021"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"
 
 [dependencies]
-rand = "0.8"
-
-# Bindgen for generating Rust bindings for C/C++ libraries
-bindgen = "0.69"
-
-# Core binary parsing
-serde = { version = "1.0", features = ["derive"] }
-bincode = "1.3"
-byteorder = "1.5"
-bytes = "1.4"
-
-# Advanced parsing
-nom = "7.1"
-deku = "0.16"
-
-# Protocol support
-prost = "0.12"
-rmp-serde = "1.1"
-
-# Utilities
-hex = "0.4"
-crc = "3.0"
-thiserror = "1.0"
-
-# Kafka/Redpanda client
-rdkafka = { version = "0.36", features = ["cmake-build", "ssl", "sasl"] }
-
-# Async runtime
-tokio = { version = "1.0", features = ["full"] }
-tokio-stream = "0.1"
-
-# Additional async utilities
-futures = "0.3"
+arrow = { version = "58.0.0", features = [
+  "csv",
+  "json",
+  "ipc",
+  "ipc_compression",
+  "prettyprint",
+  "chrono-tz",
+  "ffi",
+  "pyarrow",
+  "canonical_extension_types",
+  "async",
+] }
+assert_matches = "1.5"
 async-trait = "0.1"
-
-# JSON handling for Kafka messages
+bindgen = "0.72"
+byteorder = "1.5"
+bytes = "1.11"
+chrono = { version = "0.4", features = ["serde"] }
+crc = "3.4"
+criterion = { version = "0.8", features = ["html_reports"] }
+deku = "0.20"
+env_logger = "0.11"
+fake = { version = "4.4", features = ["derive", "chrono", "uuid"] }
+futures = "0.3"
+futures-test = "0.3"
+hex = "0.4"
+httpmock = "0.8"
+insta = { version = "1.46", features = ["json", "yaml"] }
+log = "0.4"
+mockall = "0.14"
+mysql_async = "0.36"
+nom = "8.0"
+pretty_assertions = "1.4"
+proptest = { version = "1.10", optional = true }
+prost = "0.14"
+prost-build = "0.14"
+prost-types = "0.14"
+quickcheck = { version = "1.1", optional = true }
+quickcheck_macros = { version = "1.2", optional = true }
+rand = "0.10"
+rdkafka = { version = "0.39", features = ["cmake-build", "ssl", "sasl"] }
+reqwest = { version = "0.13", features = ["json"] }
+rkyv = "0.8.15"
+rmp-serde = "1.3"
+rstest = "0.26"
+schema_registry_converter = { version = "4.8", features = [
+  "futures",
+  "proto_raw",
+] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-
-# Logging
+serde_yml = "0.0.12"
+serial_test = "3.4"
+sqlx = { version = "0.8", features = [
+  "runtime-tokio-rustls",
+  "postgres",
+  "mysql",
+  "chrono",
+  "uuid",
+  "json",
+] }
+testcontainers = { version = "0.27", optional = true }
+testcontainers-modules = { version = "0.15", features = [
+  "kafka",
+], optional = true }
+thiserror = "2.0"
+tokio = { version = "1.49", features = ["full"] }
+tokio-postgres = "0.7"
+tokio-stream = "0.1"
+tokio-test = "0.4"
+toml = "1.0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-# Database connectivity
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "mysql", "chrono", "uuid", "json"] }
-tokio-postgres = "0.7"
-mysql_async = "0.33"
-
-# Database utilities
-uuid = { version = "1.0", features = ["v4", "serde"] }
-chrono = { version = "0.4", features = ["serde"] }
-
-# Optional testing dependencies (only included when features are enabled)
-testcontainers = { version = "0.15", optional = true }
-testcontainers-modules = { version = "0.3", features = ["kafka"], optional = true }
-quickcheck = { version = "1.0", optional = true }
-quickcheck_macros = { version = "1.0", optional = true }
-proptest = { version = "1.4", optional = true }
-
-# Logging
-log = "0.4"
-env_logger = "0.11"
-
-reqwest = { version = "0.12", features = ["json"] }
-prost-types = "0.12"
-
-# Confluent-compatible Schema Registry helper for Protobuf (async, raw)
-schema_registry_converter = { version = "4.5", features = ["futures", "proto_raw"] }
-
-[build-dependencies]
-prost-build = "0.12"
-
-[dev-dependencies]
-# Core testing (always available in tests)
-tokio-test = "0.4"
-mockall = "0.12"
-httpmock = "0.7"
-assert_matches = "1.5"
-pretty_assertions = "1.4"
-serial_test = "3.0"
-criterion = { version = "0.5", features = ["html_reports"] }
-fake = { version = "2.9", features = ["derive", "chrono", "uuid"] }
-rstest = "0.19"
-insta = { version = "1.34", features = ["json", "yaml"] }
-futures-test = "0.3"
+uuid = { version = "1.21", features = ["v4", "serde"] }
+wincode = { version = "0.4.5", features = [
+  "std",
+  "alloc",
+  "derive",
+  "uuid",
+  "uuid-serde-compat",
+] }

--- a/packages/panamax/README.md
+++ b/packages/panamax/README.md
@@ -44,9 +44,9 @@ If you don't have a filled-out mirrors directory:
 
     ```toml
     platforms_unix = [
-         "x86_64-unknown-linux-gnu",
-         "i686-unknown-linux-gnu",
-         "aarch64-unknown-linux-gnu",
+          "x86_64-unknown-linux-gnu",
+          "i686-unknown-linux-gnu",
+          "aarch64-apple-darwin",
     ]
     ```
 
@@ -68,7 +68,7 @@ If you don't have a filled-out mirrors directory:
   ./panamax-init.sh
   ```
 
-  Ensure to change the base_url to match the host's ip.
+  Ensure to change the base_url to match the host's IP.
 
   Now we sync. This will ensure that we have the files we need (rustup/cargo binaries).
 

--- a/packages/panamax/docker-compose.yml
+++ b/packages/panamax/docker-compose.yml
@@ -1,8 +1,7 @@
-version: '3.1'
-
 services:
   panamax:
     image: panamaxrs/panamax
+    container_name: panamax
     volumes:
       - "./mirrors:/mirror"
     ports:

--- a/packages/panamax/mirror.base.toml
+++ b/packages/panamax/mirror.base.toml
@@ -75,11 +75,12 @@ keep_latest_nightlies = 0
 # Uncomment the following lines to limit which platforms get downloaded.
 # This affects both rustup-inits and components.
 
-# platforms_unix = [
-#     "arm-unknown-linux-gnueabi",
-#     "x86_64-unknown-linux-gnu",
-#     "x86_64-unknown-linux-musl",
-# ]
+platforms_unix = [
+  "x86_64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
+  "i686-unknown-linux-gnu",
+  "i686-unknown-linux-musl",
+]
 
 
 # Windows platforms to include in the mirror
@@ -87,8 +88,8 @@ keep_latest_nightlies = 0
 # This affects both rustup-inits and components.
 
 platforms_windows = [
-#     "x86_64-pc-windows-gnu",
-#     "x86_64-pc-windows-msvc",
+  #     "x86_64-pc-windows-gnu",
+  #     "x86_64-pc-windows-msvc",
 ]
 
 

--- a/packages/panamax/panamax-init.sh
+++ b/packages/panamax/panamax-init.sh
@@ -2,17 +2,23 @@
 set -euo pipefail
 
 # Check prerequisites
-command -v cargo >/dev/null 2>&1 || { echo "Error: cargo is required but not installed." >&2; exit 1; }
-command -v docker >/dev/null 2>&1 || { echo "Error: docker is required but not installed." >&2; exit 1; }
+command -v cargo >/dev/null 2>&1 || {
+  echo "Error: cargo is required but not installed." >&2
+  exit 1
+}
+command -v docker >/dev/null 2>&1 || {
+  echo "Error: docker is required but not installed." >&2
+  exit 1
+}
 
 # Create a vendor directory with all the intended binaries
 cargo vendor --manifest-path ./Cargo.toml ./mirrors/vendor
 
-# Initialize the panamax files needed for panamax
+# Initialize the files needed for panamax
 docker run --rm -v ./mirrors:/mirror --user "$(id -u)" panamaxrs/panamax init /mirror
 
 # Overwrite mirror toml with base existing one
-cp ./mirror.toml.base ./mirrors/mirror.toml
+cp ./mirror.base.toml ./mirrors/mirror.toml
 
 echo "Initialization successful"
-echo "Please remember to edit the base_url within mirrors/mirror.toml to match the ip of the machine!"
+echo 'Please remember to edit the "base_url" within "mirrors/mirror.toml" to match the IP of the machine!'

--- a/packages/panamax/src/main.rs
+++ b/packages/panamax/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("This is a trivial source file to allow vendoring");
+}


### PR DESCRIPTION
- Adds crates for Apache Arrow, YAML, and TOML
- Add crates `wincode` and `rkyv` to replace `bincode`
- Renamed `mirror.toml.base` to `mirror.base.toml`, to keep syntax highlighting in editors looking for the `.toml` extension
- Added GNU and musl Rustup targets for both x86_64 and i686
- I updated crate versions
- Rather than grouping by use, I organized alphabetically. That should help us avoid duplicates.
I had trouble getting Cargo.toml to resolve without a compile target, so I needed to create a trivial src/lib.rs.
- Other small changes like specifying the container name in the `docker-compose.yml`